### PR TITLE
implemented interest accruel after token transfer

### DIFF
--- a/score/oToken/oToken.py
+++ b/score/oToken/oToken.py
@@ -304,7 +304,7 @@ class OToken(IconScoreBase, TokenStandard):
 
     @external
     def burnOnLiquidation(self, _user: Address, _value: int) -> None:
-        cumulated = self._cumulateBalanceInternal(self.msg.sender)
+        cumulated = self._cumulateBalanceInternal(_user)
         currentBalance = cumulated['principalBalance']
         balanceIncrease = cumulated['balanceIncrease']
         index = cumulated['index']


### PR DESCRIPTION
added logic for interest accumulation and cumulative index set,check before transfer and bug fixes

1. When oToken is transferred from Account-A to Account-B:
          -check whether balance transfer from Account-A is allowed or not
          - accrued interest to that instant of time for Account-A is minted,new liquidity cumulative index is set for user Account-A
          - accrued interest to that instant of time for Account-B(if any) ,new liquidity cumulative index is set for user Account-B
          - token is transferred from Account-A to Account-B
          - interest is accrued in both Account-A and Account-B

2. bug fixes:
    - method name changed as per the naming convention
    - self.msg.sender changed to "_user" while resetting index and burning on liquidation