### PR TITLE
typecast int key to str for dict response

### DIFF
--- a/score/rewardDistribution/rewardConfigurationDB.py
+++ b/score/rewardDistribution/rewardConfigurationDB.py
@@ -169,7 +169,7 @@ class RewardConfigurationDB(object):
         for asset in self._assets:
             _poolID = self._poolIDMapping[asset]
             if _poolID > 0:
-                configs[_poolID] = self.getAssetPercentage(asset)
+                configs[str(_poolID)] = self.getAssetPercentage(asset)
 
         return {'liquidity': configs}
 


### PR DESCRIPTION
explicitly typecasted the key of response from **_int_** to **_str_** in `distPercentageOfAllLP` method of reward score